### PR TITLE
Improvements for cellular network interface handling

### DIFF
--- a/core_manager/modules/network.py
+++ b/core_manager/modules/network.py
@@ -90,7 +90,6 @@ class Network(object):
                         if network.find("Ethernet interface") >= 0:
                             if network.find("driver=cdc_ether") >= 0:
                                 interface.if_type=InterfaceTypes.CELLULAR
-                                modem.interface_name = interface.name
                             else:
                                 interface.if_type=InterfaceTypes.ETHERNET
                         elif network.find("Wireless interface") >= 0:

--- a/core_manager/modules/network.py
+++ b/core_manager/modules/network.py
@@ -10,6 +10,11 @@ from cm import modem
 
 LOWEST_PRIORTY_FACTOR = 100
 
+class InterfaceTypes:
+    CELLULAR = 'C'
+    ETHERNET = 'E'
+    WIFI = 'W'
+
 
 def parse_output(string, header, end):
     header += " "
@@ -52,19 +57,18 @@ class Network(object):
         interface.name = name
         self.interfaces.append(interface)
 
-    def remove_interface(self, value):
-        self.interfaces.remove(value)
+    def remove_interface(self, name):
+        for iface in self.interfaces:
+            if iface.name == name:
+                self.interfaces.remove(iface)
 
     def check_interfaces(self):
-        actual = []
-
         try:
             usables = self.find_usable_interfaces()
         except Exception as error:
             logger.error("find_usable_interfaces() --> %s", error)
 
-        for interface in self.interfaces:
-            actual.append(interface.name)
+        actual = [ interface.name for interface in self.interfaces ]
 
         for usable_if in usables:
             if usable_if not in actual:
@@ -72,9 +76,7 @@ class Network(object):
 
         for actual_if in actual:
             if actual_if not in usables:
-                for self_if in self.interfaces:
-                    if self_if.name == actual_if:
-                        self.remove_interface(self_if)
+                self.remove_interface(actual_if)
 
     def get_interface_type(self):
         output = shell_command("lshw -C Network")
@@ -87,12 +89,12 @@ class Network(object):
                     if network.find(interface.name) >= 0:
                         if network.find("Ethernet interface") >= 0:
                             if network.find("driver=cdc_ether") >= 0:
-                                interface.if_type="C"   # cellular
+                                interface.if_type=InterfaceTypes.CELLULAR
                                 modem.interface_name = interface.name
                             else:
-                                interface.if_type="E"   # ethernet
+                                interface.if_type=InterfaceTypes.ETHERNET
                         elif network.find("Wireless interface") >= 0:
-                            interface.if_type="W"       # wifi
+                            interface.if_type=InterfaceTypes.WIFI
         else:
             logger.warning("Error occured on --> get_interface_type")
 
@@ -158,7 +160,7 @@ class Network(object):
         self.get_interface_priority()
 
         for ifs in self.interfaces:
-            if ifs.if_type == "Cellular":
+            if ifs.if_type == InterfaceTypes.CELLULAR:
                 ifs.connection_status = modem.monitor.get("cellular_connection")
                 self.monitor[ifs.name] = [ifs.connection_status, ifs.if_type, ifs.priority]
             else:


### PR DESCRIPTION
This PR contains two fixes:

1. `get_interface_type()` sets `if_type` to either `"C"`, `"E"` or `"W"` for cellular/ethernet/WiFi interfaces respectively.  However `check_and_create_monitoring()` checks for the value `"Cellular"` to identify cellular interfaces.  This change introduces a small helper class to ensure that the values remain consistent.
2. The name of the cellular interface can change due to a number of different events (in particular, a reset of the kernel driver). Therefore the interface name determined by the `nm` thread may be obsolete by the time that the connection is established.  If `check_internet()` attempts to use the old interface name then the ping command will fail, leading to an unnecessary disconnection cycle.