### PR TITLE
fix: jetson nano hard reboot

### DIFF
--- a/core_manager/helpers/config.py
+++ b/core_manager/helpers/config.py
@@ -25,7 +25,7 @@ configs_showed_at_frontend = [
 
 default_config = {
     "apn": core_env.get("apn", "super"),
-    "sbc": core_env.get("sbc", "rpi4"),
+    "sbc": core_env.get("board", "rpi4"),
     "debug_mode": False,
     "verbose_mode": False,
     "check_internet_interval": 60,

--- a/core_manager/helpers/sbc_support.py
+++ b/core_manager/helpers/sbc_support.py
@@ -66,4 +66,4 @@ class SBC:
 rpi4_raspbian = SBC("Raspberry Pi 4", "Raspberry Pi OS (Raspbian)", 26)  # Use BCM on Raspberry Pi
 jetson_nano_ubuntu = SBC("Nvidia Jetson Nano", "Ubuntu", 194)  # Use SYSFS on Jetson
 
-supported_sbcs = {"rpi4": rpi4_raspbian, "jetson_nano_ubuntu": jetson_nano_ubuntu}
+supported_sbcs = {"rpi4": rpi4_raspbian, "Jetson": jetson_nano_ubuntu}


### PR DESCRIPTION
Jetson Nano could not be detected as a board so the core_manager service could not hard reboot the board.
