### PR TITLE
fix: interface naming and gpio operations

### DIFF
--- a/core_manager/helpers/modem_support/default.py
+++ b/core_manager/helpers/modem_support/default.py
@@ -371,7 +371,6 @@ class BaseModule:
 
     def reset_modem_hardly(self):
         logger.info("Modem is resetting via hardware...")
-        time.sleep(6)
         # Add workaround for rpi5
         output = shell_command("cat /sys/firmware/devicetree/base/model")
         if output[2] == 0:

--- a/core_manager/helpers/modem_support/default.py
+++ b/core_manager/helpers/modem_support/default.py
@@ -79,7 +79,8 @@ class BaseModule:
         for interface in network_interfaces:
             try:
                 cmd = f"ethtool -i {interface}"
-                result = subprocess.run(cmd, shell=True, universal_newlines=True, capture_output=True)
+                result = subprocess.run(cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
                 if result.returncode != 0:
                     continue
                 lines = result.stdout.splitlines()

--- a/core_manager/helpers/modem_support/default.py
+++ b/core_manager/helpers/modem_support/default.py
@@ -64,10 +64,11 @@ class BaseModule:
     def __init__(self, module_name="default", pid="ffff"):
         self.module_name = module_name
         self.pid = pid
+        
         if_name = self.get_network_interface_name()
         if if_name:
             self.interface_name = if_name
-
+        
     def get_network_interface_name(self):
         cellular_drivers = ["cdc_ether", "cdc_ncm", "qmi_wwan", "rndis_host", "cdc_mbim"]
         try:
@@ -78,7 +79,7 @@ class BaseModule:
         for interface in network_interfaces:
             try:
                 cmd = f"ethtool -i {interface}"
-                result = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+                result = subprocess.run(cmd, shell=True, universal_newlines=True, capture_output=True)
                 if result.returncode != 0:
                     continue
                 lines = result.stdout.splitlines()

--- a/core_manager/helpers/modem_support/default.py
+++ b/core_manager/helpers/modem_support/default.py
@@ -377,9 +377,7 @@ class BaseModule:
                 conf.sbc = "rpi5"
 
         sbc = supported_sbcs.get(conf.sbc)
-        sbc.modem_power_disable()
-        time.sleep(2)
-        sbc.modem_power_enable()
+        sbc.modem_hard_reset()
 
     def get_significant_data(self, output, header):
         header += " "

--- a/core_manager/helpers/modem_support/default.py
+++ b/core_manager/helpers/modem_support/default.py
@@ -377,7 +377,9 @@ class BaseModule:
                 conf.sbc = "rpi5"
 
         sbc = supported_sbcs.get(conf.sbc)
-        sbc.modem_hard_reset()
+        sbc.modem_power_disable()
+        sbc.modem_power_enable()
+        logger.info("Modem is resetted via hardware.")
 
     def get_significant_data(self, output, header):
         header += " "

--- a/core_manager/helpers/modem_support/default.py
+++ b/core_manager/helpers/modem_support/default.py
@@ -68,7 +68,7 @@ class BaseModule:
         if if_name:
             self.interface_name = if_name
 
-    def get_network_interface_name():
+    def get_network_interface_name(self):
         cellular_drivers = ["cdc_ether", "cdc_ncm", "qmi_wwan", "rndis_host", "cdc_mbim"]
         try:
             network_interfaces = os.listdir("/sys/class/net/")

--- a/core_manager/helpers/modem_support/default.py
+++ b/core_manager/helpers/modem_support/default.py
@@ -377,9 +377,9 @@ class BaseModule:
                 conf.sbc = "rpi5"
 
         sbc = supported_sbcs.get(conf.sbc)
+        sbc.gpio_check()
         sbc.modem_power_disable()
         sbc.modem_power_enable()
-        logger.info("Modem is resetted via hardware.")
 
     def get_significant_data(self, output, header):
         header += " "

--- a/core_manager/helpers/modem_support/default.py
+++ b/core_manager/helpers/modem_support/default.py
@@ -369,7 +369,7 @@ class BaseModule:
 
     def reset_modem_hardly(self):
         logger.info("Modem is resetting via hardware...")
-
+        time.sleep(6)
         # Add workaround for rpi5
         output = shell_command("cat /sys/firmware/devicetree/base/model")
         if output[2] == 0:

--- a/core_manager/helpers/sbc_support.py
+++ b/core_manager/helpers/sbc_support.py
@@ -1,4 +1,4 @@
-from subprocess import check_output, getstatusoutput
+from subprocess import run, check_output, getstatusoutput, CalledProcessError
 from helpers.logger import logger
 import time
 
@@ -49,12 +49,18 @@ class SBC:
         except Exception as e:
             logger.exception(f"modem_power_disable --> {e}")
 
-    def kill_gpioset(self):
+    def kill_gpioset():
         comm = 'pkill -9 -f "gpioset --mode=wait"'
         try:
-            check_output(comm, shell=True)
-        except Exception as e:
+            result = run(comm, shell=True, check=False)
+            if result.returncode == 0:
+                logger.info("Successfully killed gpioset process.")
+            else:
+                logger.warning("No running gpioset process found to kill.")
+        except CalledProcessError as e:
             logger.exception(f"kill_gpioset --> {e}")
+        except Exception as e:
+            logger.exception(f"Unexpected error in kill_gpioset --> {e}")
             
 # SBC configurations for different boards
 rpi4_raspbian = SBC("Raspberry Pi 4", "Raspberry Pi OS (Raspbian)", 26)  # Use BCM pin number on Raspberry Pi

--- a/core_manager/helpers/sbc_support.py
+++ b/core_manager/helpers/sbc_support.py
@@ -1,4 +1,4 @@
-from subprocess import run, check_output, getstatusoutput, CalledProcessError
+from subprocess import Popen, run, getstatusoutput, CalledProcessError
 from helpers.logger import logger
 import time
 
@@ -14,9 +14,8 @@ class SBC:
         self.chip_name = chip_name
 
     def gpio_check(self, pin):
-        # gpiod CLI does not need initialization, so we just check if the GPIO is accessible.
+        """ Check if the GPIO is accessible using gpiod CLI. """
         pin_name = f"{self.chip_name} {pin}"
-
         try:
             status, output = getstatusoutput(f"gpioinfo {self.chip_name}")
             if status != 0 or f"{pin}" not in output:
@@ -24,47 +23,43 @@ class SBC:
         except Exception as e:
             logger.exception(f"gpio_check --> {e}")
 
-    def modem_hard_reset(self):
-        self.gpio_check(self.disable_pin)
-
-        self.kill_gpioset()
-        self.modem_power_disable()
-        time.sleep(2)
-        self.kill_gpioset()
-        self.modem_power_enable()
-        self.kill_gpioset()
-        logger.info("Modem hard reset completed.")
-        
     def modem_power_enable(self):
-        comm = f"gpioset --mode=wait {self.chip_name} {self.disable_pin}=0 &"
+        """ Set GPIO LOW (Enable modem) and wait 2 seconds before killing gpioset. """
+        self.gpio_check(self.disable_pin)
+        comm = f"gpioset --mode=wait {self.chip_name} {self.disable_pin}=0"
         try:
-            check_output(comm, shell=True)
-            logger.info("Modem power enabled.")
+            process = Popen(comm, shell=True)  # Run gpioset in the background
+            logger.info("Modem power enabled (GPIO LOW).")
+            self.kill_gpioset()
         except Exception as e:
             logger.exception(f"modem_power_enable --> {e}")
 
     def modem_power_disable(self):
-
-        comm = f"gpioset --mode=wait {self.chip_name} {self.disable_pin}=1 &"
+        """ Set GPIO HIGH (Disable modem) and wait 2 seconds before killing gpioset. """
+        self.gpio_check(self.disable_pin)
+        comm = f"gpioset --mode=wait {self.chip_name} {self.disable_pin}=1"
         try:
-            check_output(comm, shell=True)
-            logger.info("Modem power disabled.")
+            process = Popen(comm, shell=True)  # Run gpioset in the background
+            logger.info("Modem power disabled (GPIO HIGH).")
+            time.sleep(2)
+            self.kill_gpioset()
         except Exception as e:
             logger.exception(f"modem_power_disable --> {e}")
 
     def kill_gpioset(self):
+        """ Kill any running gpioset processes. """
         comm = 'pkill -9 -f "gpioset --mode=wait"'
         try:
             result = run(comm, shell=True, check=False)
             if result.returncode == 0:
                 logger.info("Successfully killed gpioset process.")
             else:
-                logger.warning("No running gpioset process found to kill.")
+                logger.info("No running gpioset process found to kill.")
         except CalledProcessError as e:
             logger.exception(f"kill_gpioset --> {e}")
         except Exception as e:
             logger.exception(f"Unexpected error in kill_gpioset --> {e}")
-            
+
 # SBC configurations for different boards
 rpi4_raspbian = SBC("Raspberry Pi 4", "Raspberry Pi OS (Raspbian)", 26)  # Use BCM pin number on Raspberry Pi
 jetson_nano_ubuntu = SBC("Nvidia Jetson Nano", "Ubuntu", 194)  # GPIO pin on Jetson Nano

--- a/core_manager/helpers/sbc_support.py
+++ b/core_manager/helpers/sbc_support.py
@@ -19,7 +19,7 @@ class SBC:
 
         try:
             status, output = getstatusoutput(f"gpioinfo {self.chip_name}")
-            if status != 0 or f"line   {pin}" not in output:
+            if status != 0 or f"{pin}" not in output:
                 logger.warning(f"GPIO {pin_name} not accessible or not available.")
         except Exception as e:
             logger.exception(f"gpio_check --> {e}")
@@ -33,11 +33,13 @@ class SBC:
         self.kill_gpioset()
         self.modem_power_enable()
         self.kill_gpioset()
+        logger.info("Modem hard reset completed.")
         
     def modem_power_enable(self):
         comm = f"gpioset --mode=wait {self.chip_name} {self.disable_pin}=0 &"
         try:
             check_output(comm, shell=True)
+            logger.info("Modem power enabled.")
         except Exception as e:
             logger.exception(f"modem_power_enable --> {e}")
 
@@ -46,10 +48,11 @@ class SBC:
         comm = f"gpioset --mode=wait {self.chip_name} {self.disable_pin}=1 &"
         try:
             check_output(comm, shell=True)
+            logger.info("Modem power disabled.")
         except Exception as e:
             logger.exception(f"modem_power_disable --> {e}")
 
-    def kill_gpioset():
+    def kill_gpioset(self):
         comm = 'pkill -9 -f "gpioset --mode=wait"'
         try:
             result = run(comm, shell=True, check=False)


### PR DESCRIPTION
- Dynamic interface name assigning feature is added.
- Sysfs is deprecated, so gpio operations performed using gpiod package.
- Tested and approved with these devices: buster RPi4, bullseye RPi3, bookworm RPi5 and JetPack 4.6.1 Jetson Nano.